### PR TITLE
Fix: add CMAKE_BUILD_TYPE_UPPER definition

### DIFF
--- a/Packaging.cmake
+++ b/Packaging.cmake
@@ -27,6 +27,7 @@ endfunction()
 function(windeployqt target)
 
     # Bundle Library Files
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
     if(CMAKE_BUILD_TYPE_UPPER STREQUAL "DEBUG")
         set(WINDEPLOYQT_ARGS --debug)
     else()


### PR DESCRIPTION
Bug fix: CMAKE_BUILD_TYPE_UPPER is undefined， add it.